### PR TITLE
Re-implements dialog extensions

### DIFF
--- a/lib/watirmark/controller/dialogs.rb
+++ b/lib/watirmark/controller/dialogs.rb
@@ -1,33 +1,33 @@
 module Watirmark
   module Dialogs
+
+    # Assumes 2 windows
     def modal_exists?
-      !!(Page.browser.windows.size > 1)
+      Page.browser.window(:index, 1).exists?
     end
 
-    def with_modal_dialog
+    # Uses last window
+    def with_modal_dialog &blk
       wait_for_modal_dialog
-      parent_window = (Page.browser.windows.size) - 2
-      begin
-        Page.browser.windows.last.use
-        Page.browser.wait
-        yield
-      ensure
-        Page.browser.windows[parent_window].use
-      end
+      Page.browser.windows.last.use &blk
     end
 
+    # TODO - Depricate when implement smart_waits
     def wait_for_modal_dialog
-      begin
-        Timeout::timeout(30) {
-          until modal_exists?
-            sleep 0.002
-          end
-          Page.browser.wait
-          sleep 0.02
-        }
-      rescue Timeout::Error
-        raise Watirmark::TestError, 'Timed out while waiting for modal dialog to open'
-      end
+      Watir::Wait.until { modal_exists? && Page.browser.wait}
+    rescue TimeoutError
+      raise Watirmark::TestError, 'Timed out while waiting for modal dialog to open'
     end
+
+    def close_chrome_windows
+      chrome_window = Page.browser.window(:url, /chrome-extension/)
+      chrome_window.close if chrome_window.exists?
+    end
+
+    # Assumes 2 windows
+    def close_modal_window
+      Page.browser.window(:index, 1) if modal_exists?
+    end
+
   end
 end


### PR DESCRIPTION
We discussed changing implementation or at least changing the naming of this. While going through the watir-webdriver code, I realized that we are either mis-implementing it, or unnecessarily abstracting and obfuscating.

I'd be surprised if we need the extra Page.browser.wait calls or the special error message, in which case we can replace all 3 of these with one line of watir-webdriver code. I suggest we announce the deprecation of these 3 methods, modify our test code to use the actual watir-webdriver nomenclature, and then remove the file in the next version of watirmark.

Examples of a single line of watir-webdriver code that should capture all 3 of these methods (and I doubt when_present is actually necessary, even):
Page.browser.window(:index, 1).when_present blk
Page.browser.window(:title, /Your Test Should Know This/).when_present blk
Page.browser.window(:url, /your_test_should_know_this_too/).when_present blk

Also of note, CLO overrides these methods anyway (to address later), so I wonder if we're actually using this particular code anywhere at this point.
