### PR TITLE
Updates default firefox profile for focusmanager to be in testmode

### DIFF
--- a/lib/watirmark/session.rb
+++ b/lib/watirmark/session.rb
@@ -94,6 +94,7 @@ module Watirmark
         profile['security.warn_viewing_mixed.show_once'] =  false
         profile['security.mixed_content.block_active_content'] = false
       end
+      profile["focusmanager.testmode"] = true
       profile
     end
 


### PR DESCRIPTION
Firefox has issues where it sometimes needs to be the active window in the operating system for an action to work correctly. I'm not sure if this will make a difference in our tests, but I'm working with it turned on to see if it hurts.
