### PR TITLE
Implements a configurable wait class

### DIFF
--- a/lib/watirmark.rb
+++ b/lib/watirmark.rb
@@ -16,4 +16,5 @@ require 'watirmark/model'
 require 'watirmark/rake/smoketest'
 require 'active_support/inflector'
 require 'watirmark/screenshot'
+require 'watirmark/wait'
 FileUtils.rm_rf('reports/screenshots')

--- a/lib/watirmark/wait.rb
+++ b/lib/watirmark/wait.rb
@@ -1,0 +1,53 @@
+module Watirmark
+  class Wait
+
+    DEFAULT_TIMEOUT = 30
+    DEFAULT_INTERVAL = 2
+
+    #
+    # Create a new Wait instance
+    #
+    # @param [Hash] opts Options for this instance
+    # @option opts [Numeric] :timeout (5) Seconds to wait before timing out.
+    # @option opts [Numeric] :interval (0.2) Seconds to sleep between polls.
+    # @option opts [String] :message Exception message if timed out.
+    #
+
+    def initialize(opts = {})
+      @timeout = opts.fetch(:timeout, DEFAULT_TIMEOUT)
+      @interval = opts.fetch(:interval, DEFAULT_INTERVAL)
+      @message = opts.fetch(:message, '')
+    end
+
+    #
+    # Wait until the given block returns a true value.
+    #
+    # @raise [TimeOutError::Error]
+    # @return [Object] the result of the block
+    #
+
+    def until(&blk)
+      end_time = Time.now + @timeout
+      last_error = nil
+
+      until Time.now > end_time
+        result = yield
+        return result if result
+        sleep @interval
+      end
+
+
+      if @message
+        msg = @message.dup
+      else
+        msg = "timed out after #{@timeout} seconds"
+      end
+
+      msg << " (#{last_error.message})" if last_error
+
+      raise Timeout::Error, msg
+    end
+
+  end
+end
+

--- a/spec/wait_spec.rb
+++ b/spec/wait_spec.rb
@@ -1,0 +1,31 @@
+require File.expand_path("../spec_helper", __FILE__)
+
+module Watirmark
+  describe Wait do
+
+    def wait(*args)
+      Wait.new(*args)
+    end
+
+    it 'should wait until the returned value is true' do
+      count = 0
+      wait(timeout: 1, interval: 0.5).until { (count += 1) > 1}.should be true
+    end
+
+    it 'should poll the correct number of times' do
+      count = 0
+      begin
+        wait(timeout: 1, interval: 0.2).until { (count += 1; false)}
+      rescue Timeout::Error
+      end
+      expect(count).to be 5
+    end
+
+    it 'should raise a TimeOutError with correct message if the the timer runs out' do
+      expect {
+        wait(timeout: 0.1, message: 'Correct Message').until { false }
+      }.to raise_error(Timeout::Error, 'Correct Message')
+    end
+
+  end
+end


### PR DESCRIPTION
For things a test needs to wait for that aren't Watir elements
Watir::Wait hard-codes the polling interval to 0.1 (which makes sense when checking for element-related things)
With this Watirmark::Wait implementation, the poll interval can be set for a longer peried for things like API or Database updates or anything that is expected to take longer to show up that shouldn't be pinged as frequently.
This has the additional advantage of making any direct references to 'sleep'  in other places in test code to be a recognizable bad practice.
