### PR TITLE
improve logic and error if missing process page

### DIFF
--- a/lib/watirmark/page/keyed_element.rb
+++ b/lib/watirmark/page/keyed_element.rb
@@ -29,7 +29,6 @@ module Watirmark
 
     def set val
       return if val.nil?
-      @process_page.activate
       element = get
       val = @map.lookup(val) if @map
       case val

--- a/lib/watirmark/page/page.rb
+++ b/lib/watirmark/page/page.rb
@@ -33,9 +33,9 @@ module Watirmark
 
     def create_keyword_methods
       keywords = self.class.keyword_metadata || {}
-      keywords.each_key do |key|
-        keyed_element = KeyedElement.new(self, keywords[key])
-        next if !@keyed_elements.empty? and @keyed_elements.any? {|k| k.keyword.eql? keyed_element.keyword }
+      keywords.each do |key, value|
+        keyed_element = KeyedElement.new(self, value)
+        next if @keyed_elements.any? {|k| k.keyword.eql? keyed_element.keyword }
         @keyed_elements << keyed_element
         meta_def key do |*args|
           keyed_element.get *args

--- a/lib/watirmark/page/process_page.rb
+++ b/lib/watirmark/page/process_page.rb
@@ -71,6 +71,7 @@ module Watirmark
 
     def goto_process_page
       unless navigate
+        raise Watirmark::TestError, "Unable to navigate to Process Page: #{name}" if aliases.empty?
         aliases.each do |alias_name|
           alias_process_page = self.dup
           alias_process_page.alias = []

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -55,6 +55,7 @@ describe Watirmark::WebPage::Controller do
   end
 
   class ProcessPageControllerView < Page
+    process_page_navigate_method Proc.new { true }
 
     keyword(:a) { Element.new :a }
     process_page('Page 1') do


### PR DESCRIPTION
Fixes duplicate actions and incorrect logic.
Raises error if unsuccessfully able to navigate to process page.
Current implementation works if the process page is named incorrectly, but you happen to be on it, anyway.
Otherwise it fails on finding the first element in the process page rather than giving a better error for not finding the process page itself.
A number of tests *will fail with this commit because a number of our Views are out of date.