### PR TITLE
remove override for always locating elements

### DIFF
--- a/lib/watirmark/extensions/webdriver_extensions.rb
+++ b/lib/watirmark/extensions/webdriver_extensions.rb
@@ -1,7 +1,5 @@
 require 'watir-webdriver/extensions/select_text'
 
-Watir::always_locate = false
-
 module Watir
 
   class Browser


### PR DESCRIPTION
Our framework should not be overriding the default. 
This should decrease flaky tests. If a given test is solid and would receive a major performance boost by caching elements, the override should be set in the test itself.