### PR TITLE
Use Configuration file to override Watir defaults

### DIFF
--- a/lib/watirmark/configuration.rb
+++ b/lib/watirmark/configuration.rb
@@ -23,6 +23,9 @@ module Watirmark
         :uuid               => nil,
         :webdriver          => :firefox,
         :headless           => false,
+        :always_locate      => true,
+        :prefer_css         => false,
+        :watir_timeout      => 30,
         :http_timeout       => 60,
         # database
         :dbhostname         => nil,

--- a/lib/watirmark/session.rb
+++ b/lib/watirmark/session.rb
@@ -117,6 +117,10 @@ module Watirmark
     end
 
     def openbrowser
+      Watir.default_timeout = config.watir_timeout
+      Watir.prefer_css = config.prefer_css
+      Watir.always_locate = config.always_locate
+
       use_headless_display if config.headless
       Page.browser = new_watir_browser
       initialize_page_checkers


### PR DESCRIPTION
These are the 3 settings configurable in the base file of Watir, and they should be available to be set in configuration file like other Watirmark options. This should be considered along with #30, if some tests need to cache elements for performance reasons.