### PR TITLE
Add alias method #has for updating model with specified keyword values

### DIFF
--- a/lib/watirmark/models/factory.rb
+++ b/lib/watirmark/models/factory.rb
@@ -109,6 +109,7 @@ module Watirmark
         hash.each_pair { |key, value| send "#{key}=", value }
         self
       end
+      alias :has :update
 
 
       # Update the model using the provided hash but only if exists (TODO: may not be needed any more)


### PR DESCRIPTION
> Summary: Model `#has` can be used to define additional keyword values on a model -- semantically preferable to using `#update` because test code reads more like test intent.

There is this prevailing idea that a model is just a ‘glorified hash’:
` my_hashy_model.update { name => 'Anthony', occupation => 'programmer' } `

If you are an experienced Rubyist and you like Hashes, you may tell me "using the method named `#update` makes fine sense".

But I think when writing test code, it also makes sense to take a DSL approach. In this scenario I prefer adding keyword/values to a model with something like “has”:
` my_model.has name: 'Anthony', occupation: 'tester' `

Because this way of writing it really gets to the point of that line of my test -- it tells the reader that my test uses some model which *has* certain attributes (i.e., whatever attributes are relevant to the test at hand). 

Only behind-the-scenes does it matter my model happens to include a hash which is getting *updated* when that line is executed. In the test code itself, I do not wish to suggest that *updating* the model has anything to do with my test (because after all, we are testing Luminate -- not Models). 


Yes, this is a pretty insignificant change. The main reason I submit this pull request is that I hope it hints at other ways to make Watirmark less coding-focused, and more testing-focused. Everyone please feel free to comment and use this PR for any discussion that you see fit.