### PR TITLE
Add support for changing http client timeout

### DIFF
--- a/lib/watirmark/configuration.rb
+++ b/lib/watirmark/configuration.rb
@@ -23,6 +23,7 @@ module Watirmark
         :uuid               => nil,
         :webdriver          => :firefox,
         :headless           => false,
+        :http_timeout       => 60,
         # database
         :dbhostname         => nil,
         :dbusername         => nil,

--- a/lib/watirmark/session.rb
+++ b/lib/watirmark/session.rb
@@ -162,15 +162,16 @@ module Watirmark
     end
 
     def new_watir_browser
-      config.webdriver ||= :firefox
-      if config.webdriver.to_sym == :firefox
-        Watir::Browser.new config.webdriver.to_sym, :profile => config.firefox_profile
-      elsif config.webdriver.to_sym == :firefox_proxy
-        Watir::Browser.new :firefox, :profile => config.firefox_profile
-      elsif config.webdriver.to_sym == :sauce
+      client = Selenium::WebDriver::Remote::Http::Default.new
+      client.timeout = config.http_timeout
+
+      case config.webdriver.to_sym
+      when :firefox, :firefox_proxy
+        Watir::Browser.new :firefox, profile: config.firefox_profile, http_client: client
+      when :sauce
         Watir::Browser.new use_sauce
       else
-        Watir::Browser.new config.webdriver.to_sym
+        Watir::Browser.new config.webdriver.to_sym, http_client: client
       end
     end
 


### PR DESCRIPTION
The Net::HTTP class from Ruby's standard library has a default timeout of 60 seconds between driver calls, so tests with long page loads or sleeps, etc might need a timeout greater than 60 seconds.
http://stackoverflow.com/questions/9014121/how-do-i-change-the-page-load-timeouts-in-watir-webdriver-timeout-in-click-met