### PR TITLE
Prevent nil class from being extended to be Ruby 2.2 compatible

### DIFF
--- a/lib/watirmark/page/keyed_element.rb
+++ b/lib/watirmark/page/keyed_element.rb
@@ -21,6 +21,7 @@ module Watirmark
     def get *args
       @process_page.activate
       watir_object = @context.instance_exec(*args, &@block)
+      return if watir_object.nil?
       watir_object.extend(KeywordMethods)
       watir_object.radio_map = @map if @map
       watir_object.keyword = @keyword


### PR DESCRIPTION
Should be ok to call #get on a keyword and have it return nil (keywords are often not defined by locator, but need to be navigated to by process page information). But needs a return so that code doesn't try to extend the nil class.