### PR TITLE
Support for Latest Watir version

### DIFF
--- a/lib/watirmark/extensions/webdriver_extensions.rb
+++ b/lib/watirmark/extensions/webdriver_extensions.rb
@@ -4,26 +4,6 @@ Watir::always_locate = false
 
 module Watir
 
-  class Browser
-    # for modal dialogs that close on submission, these might
-    # fail to run because the window has been destroyed
-    alias :old_run_checkers :run_checkers
-
-    # this is basically a check to make sure we're not
-    # running the checkers on a modal dialog that has closed
-    # by the time the checkers have run
-    def run_checkers
-      @error_checkers.each do |checker|
-        begin
-          checker.call(self)
-        rescue Selenium::WebDriver::Error::UnknownError, Selenium::WebDriver::Error::NoSuchWindowError => e
-          Watirmark.logger.warn "Unable to run checker: #{e.message}"
-          break
-        end
-      end
-    end
-  end
-
   module Container
     alias :row :tr
     alias :cell :td

--- a/lib/watirmark/extensions/webdriver_extensions.rb
+++ b/lib/watirmark/extensions/webdriver_extensions.rb
@@ -1,7 +1,5 @@
 require 'watir-webdriver/extensions/select_text'
 
-Watir::always_locate = false
-
 module Watir
 
   module Container

--- a/lib/watirmark/extensions/webdriver_extensions.rb
+++ b/lib/watirmark/extensions/webdriver_extensions.rb
@@ -123,11 +123,10 @@ module Watir
   end
 
   class TextFieldLocator
-    def validate_element(element)
+    def check_deprecation(element)
       if element.tag_name.downcase == 'textarea'
         warn "Locating textareas with '#text_field' is deprecated. Please, use '#textarea' method instead for #{@selector}"
       end
-      super
     end
   end
 

--- a/lib/watirmark/page/keyed_element.rb
+++ b/lib/watirmark/page/keyed_element.rb
@@ -30,7 +30,6 @@ module Watirmark
 
     def set val
       return if val.nil?
-      @process_page.activate
       element = get
       val = @map.lookup(val) if @map
       case val

--- a/watirmark.gemspec
+++ b/watirmark.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*.rb']
   s.executables = 'watirmark'
   s.require_paths = %w(lib)
-  s.add_dependency('watir-webdriver', '>= 0.6.2')
+  s.add_dependency('watir-webdriver', '>= 0.7.0')
   s.add_dependency('american_date', '~> 1.1.0')
   s.add_dependency('logger', '~> 1.2.8')
   s.add_dependency('uuid', '~> 2.3.7')


### PR DESCRIPTION
Removes unnecessary code and updated implementation based on pre-release of watir-webdriver 0.7.0

This needs to be merged in conjunction with https://github.com/convio/watir-webdriver/pull/15