### PR TITLE
When Present issue with hidden radio button options

### DIFF
--- a/lib/watirmark/controller/controller.rb
+++ b/lib/watirmark/controller/controller.rb
@@ -123,7 +123,7 @@ module Watirmark
 
       def populate_keyword_value(keyed_element)
         call_method_if_exists("populate_#{keyed_element.keyword}") do
-          @view.send(keyed_element.keyword).wait_until_present
+          @view.send(keyed_element.keyword).wait_until_present unless @view.send(keyed_element.keyword).kind_of? Watir::Radio
           @view.send("#{keyed_element.keyword}=", value(keyed_element))
         end
       end


### PR DESCRIPTION
Watirmark implements Radio buttons by passing in the name value. The first element of that name can be hidden but desired element can be present