### PR TITLE
Model edit refactor

### DIFF
--- a/lib/watirmark/controller/actions.rb
+++ b/lib/watirmark/controller/actions.rb
@@ -48,7 +48,8 @@ module Watirmark
     def edit
       search_for_record
       @view.edit @model
-      populate_data
+      populate_data(@model.updates)
+      @model.clear_updates
       check_for_noop_populate
     end
 

--- a/lib/watirmark/controller/controller.rb
+++ b/lib/watirmark/controller/controller.rb
@@ -38,14 +38,14 @@ module Watirmark
         initialize_model(data)
       end
 
-      def populate_data
-        submit_process_page(@last_process_page.underscored_name) {submit} if populate_values
+      def populate_data(updates=nil)
+        submit_process_page(@last_process_page.underscored_name) {submit} if populate_values(updates)
       end
 
-      def populate_values
+      def populate_values(updates=nil)
         @seen_value = false
         @last_process_page = nil
-        keyed_elements.each do |k|
+        keyed_update_elements(updates).each do |k|
           next unless k.populate_allowed?
           submit_process_page_when_page_changes(k)
           before_process_page(k)
@@ -157,6 +157,11 @@ module Watirmark
       def keyed_elements
         @cache = {}
         @view.keyed_elements.select{|e| !value(e).nil?}
+      end
+
+      def keyed_update_elements(updates)
+        Watirmark.logger.info("Editing these keyword(s) in populate_data: #{updates}") unless updates.nil? || updates.empty?
+        keyed_elements.select{|k| updates.nil? || updates.include?(k.keyword) }
       end
 
       def locate_model(supermodel)

--- a/lib/watirmark/models/factory.rb
+++ b/lib/watirmark/models/factory.rb
@@ -15,7 +15,7 @@ module Watirmark
       include FactoryMethodGenerators
 
       attr_accessor :defaults, :model_name, :models, :parent, :children, :model_type
-      attr_reader   :keywords
+      attr_reader   :keywords, :updates
 
       def marshal_dump
         [@keywords, @model_name, @models, @parent, @children, @model_type, self.to_h]
@@ -33,6 +33,7 @@ module Watirmark
         @search     = self.class.search || Proc.new{nil}
         @keywords   = self.class.keys.dup || []
         @children   = self.class.children.dup.map(&:new)
+        @updates    = []
         set_model_name
         set_default_values
         create_model_getters_and_setters
@@ -106,10 +107,17 @@ module Watirmark
       # Update the model using the provided hash
       def update hash
         remove_empty_entries hash
-        hash.each_pair { |key, value| send "#{key}=", value }
+        hash.each_pair do |key, value|
+          @updates << key
+          send "#{key}=", value
+        end
         self
       end
       alias :has :update
+
+      def clear_updates
+        @updates = []
+      end
 
 
       # Update the model using the provided hash but only if exists (TODO: may not be needed any more)

--- a/spec/model_factory_spec.rb
+++ b/spec/model_factory_spec.rb
@@ -99,6 +99,20 @@ describe "#update" do
     lambda{keys.update('   '.to_sym=>'') }.should_not raise_error
   end
 
+  specify "model #updates hash is updated when any keywords in the model is updated" do
+    keys = FactoryTest::UpdateModel.new
+    keys.update(:username=>'username', :foo=>'foo')
+    expect(keys.updates).to include(:username)
+    expect(keys.updates).to include(:foo)
+  end
+
+  specify "model #updates hash is cleared when #clear_updates is called" do
+    keys = FactoryTest::UpdateModel.new
+    keys.update(:username=>'username', :foo=>'foo')
+    keys.clear_updates
+    expect(keys.updates).to be_empty
+  end
+
 end
 
 describe "defaults" do
@@ -489,7 +503,7 @@ end
 describe "keywords" do
   before :all do
     module FactoryTest
-      class Element
+      class ElementTest
         attr_accessor :value
 
         def initialize(x)
@@ -498,9 +512,9 @@ describe "keywords" do
       end
 
       class SomeView < Page
-        keyword(:first_name)  { Element.new :a }
-        keyword(:middle_name) { Element.new :b }
-        keyword(:last_name)   { Element.new :c }
+        keyword(:first_name)  { ElementTest.new :a }
+        keyword(:middle_name) { ElementTest.new :b }
+        keyword(:last_name)   { ElementTest.new :c }
       end
 
       class SomeModel < Watirmark::Model::Factory


### PR DESCRIPTION
When a model is edited multiple times, it will no longer go through already edited values.