### PR TITLE
screenshots well named when fail

### DIFF
--- a/lib/watirmark/cucumber/hook_helper.rb
+++ b/lib/watirmark/cucumber/hook_helper.rb
@@ -10,9 +10,14 @@ module HookHelper
     end
 
 
-    def take_screenshot
-      image = "#{Time.now.to_i}-#{UUID.new.generate(:compact)}.png"
-      path = "reports/screenshots"
+    def take_screenshot(folder=nil, feature=nil)
+      if folder.nil?
+        path = "reports/screenshots"
+        image = "#{Time.now.to_i}-#{UUID.new.generate(:compact)}.png"
+      else
+        path = "reports/screenshots/#{folder}"
+        image = "#{feature}.png"
+      end
       file = "#{path}/#{image}"
       FileUtils.mkdir_p path unless File.directory? path
       begin

--- a/lib/watirmark/cucumber/hook_helper.rb
+++ b/lib/watirmark/cucumber/hook_helper.rb
@@ -10,17 +10,20 @@ module HookHelper
     end
 
 
-    def take_screenshot(folder=nil, feature=nil)
-      if folder.nil?
-        path = "reports/screenshots"
+    def take_screenshot(folder='', feature='')
+      path = "reports/screenshots/#{folder}"
+      if folder.empty?
         image = "#{Time.now.to_i}-#{UUID.new.generate(:compact)}.png"
       else
-        path = "reports/screenshots/#{folder}"
         image = "#{feature}.png"
       end
       file = "#{path}/#{image}"
       FileUtils.mkdir_p path unless File.directory? path
       begin
+        if Page.browser.alert.exists?
+          Watirmark.logger.warn("Alert is Open while taking screenshot: #{Page.browser.alert.text}")
+          Page.browser.alert.close
+        end
         Page.browser.screenshot.save file
         data = File.open(file, 'rb') { |f| f.read }
         data = Base64.encode64(data)

--- a/lib/watirmark/cucumber/hooks.rb
+++ b/lib/watirmark/cucumber/hooks.rb
@@ -13,8 +13,12 @@ Before do |scenario|
 end
 
 After do |scenario|
-  (file, file_type) = HookHelper.take_screenshot
-  embed file, file_type
+  unless scenario.passed?
+    folder = scenario.file[/\/features\/([^\.]*)/, 1]
+    feature = scenario.title.tr(' ', '_')
+    (file, file_type) = HookHelper.take_screenshot(folder, feature)
+    embed file, file_type
+  end
   HookHelper.serialize_models
 end
 

--- a/lib/watirmark/cucumber/hooks.rb
+++ b/lib/watirmark/cucumber/hooks.rb
@@ -13,11 +13,16 @@ Before do |scenario|
 end
 
 After do |scenario|
-  unless scenario.passed?
-    folder = scenario.location.to_s[/\/features\/([^\.]*)/, 1]
-    feature = scenario.title.tr(' ', '_')
-    (file, file_type) = HookHelper.take_screenshot(folder, feature)
-    embed file, file_type
+  if scenario.passed?
+    prepend = 'p_'
+  elsif scenario.failed?
+    prepend = 'f_'
+  else
+    prepend = 'i_'
   end
+  folder = scenario.location.to_s[/\/features\/([^\.]*)/, 1]
+  feature = prepend+scenario.title.tr(' ', '_')
+  (file, file_type) = HookHelper.take_screenshot(folder, feature)
+  embed file, file_type
   HookHelper.serialize_models
 end

--- a/lib/watirmark/cucumber/hooks.rb
+++ b/lib/watirmark/cucumber/hooks.rb
@@ -14,12 +14,10 @@ end
 
 After do |scenario|
   unless scenario.passed?
-    folder = scenario.file[/\/features\/([^\.]*)/, 1]
+    folder = scenario.location.to_s[/\/features\/([^\.]*)/, 1]
     feature = scenario.title.tr(' ', '_')
     (file, file_type) = HookHelper.take_screenshot(folder, feature)
     embed file, file_type
   end
   HookHelper.serialize_models
 end
-
-


### PR DESCRIPTION
Current file names are mostly worthless. The date/time gets stored in the filesystem itself, so that's a duplicate, and the rest are general numbers. Plus, no one looks at screenshots unless there is a failure, so storing a bunch of passing ones is profligate. 