### PR TITLE
This shouldn't be an exception

### DIFF
--- a/lib/watirmark/controller/controller.rb
+++ b/lib/watirmark/controller/controller.rb
@@ -123,7 +123,7 @@ module Watirmark
 
       def populate_keyword_value(keyed_element)
         call_method_if_exists("populate_#{keyed_element.keyword}") do
-          @view.send(keyed_element.keyword).wait_until_present unless @view.send(keyed_element.keyword).kind_of? Watir::Radio
+          @view.send(keyed_element.keyword).wait_until_present
           @view.send("#{keyed_element.keyword}=", value(keyed_element))
         end
       end


### PR DESCRIPTION
I added this as a workaround to an issue we were having where the first radio button wasn't visible, so the wait_until_present call never returned true, even though the radio button was present on the page. I believe the right answer is to override the populate_foo in the desired controller, rather than overriding it for everyone always.